### PR TITLE
Allow ApiKey, Cache-Control as request headers

### DIFF
--- a/server.js
+++ b/server.js
@@ -8,7 +8,7 @@ var _ = require('underscore'),
   url = require('url');
 
 function before(req, res, next) {
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Length, Content-Type, X-Requested-With');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Length, Content-Type, X-Requested-With, ApiKey, Cache-Control');
   res.setHeader('Access-Control-Allow-Methods', 'GET,OPTIONS');
   res.setHeader('Access-Control-Allow-Origin', '*');
 


### PR DESCRIPTION
Allows proxy to pass through authentication and setting header required to use the San Antonio BCycle API. 